### PR TITLE
Corrected export plugin range documentation.

### DIFF
--- a/tutorials/export-file.html
+++ b/tutorials/export-file.html
@@ -38,7 +38,7 @@
   columnHeaders: true, // default false
   rowHeaders: true, // default false
   columnDelimiter: ';', // default ','
-  range: [1, 1, 6, 6] // [startRow, endRow, startColumn, endColumn]
+  range: [1, 1, 6, 6] // [startRow, startColumn, endRow, endColumn]
 });</code></pre>
       </li>
     </ul>
@@ -112,7 +112,7 @@
             columnHeaders: true,        // default false, exports the column headers
             rowHeaders: true,           // default false, exports the row headers
             columnDelimiter: ';',       // default ',', the data delimiter
-            range: [1, 1, 3, 3]         // data range in format: [startRow, endRow, startColumn, endColumn]
+            range: [1, 1, 3, 3]         // data range in format: [startRow, startColumn, endRow, endColumn]
           });
           console.log(resultTextarea.value);
         });


### PR DESCRIPTION
Corrected export plugin [documentation](https://docs.handsontable.com/pro/1.17.0/demo-export-file.html) for `range`. The correct order of the parameters is:

`[startRow, startColumn, endRow, endColumn]`